### PR TITLE
Corrigindo null pointer exception no motor de audio

### DIFF
--- a/src/br/univali/portugol/nucleo/bibliotecas/Sons.java
+++ b/src/br/univali/portugol/nucleo/bibliotecas/Sons.java
@@ -265,17 +265,24 @@ public final class Sons extends Biblioteca
 
     private class Reproducao
     {
-        private final Clip reprodutor;
+        private Clip reprodutor;
         private final Integer endereco; //endereco da reprodução, não do som. O objeto Som tem outro endereço.
         private float volume = 1.0f;
         private float volumeGeral = 1.0f;
 
-        public Reproducao(Som som, AudioFormat formatoDeAudio, Integer endereco) throws LineUnavailableException, IOException, UnsupportedAudioFileException
+        public Reproducao(Som som, AudioFormat formatoDeAudio, Integer endereco) throws IOException, UnsupportedAudioFileException
         {
-            Clip clip = AudioSystem.getClip();
-            clip.open(criaStream(som, formatoDeAudio));
+            try
+            {
+                reprodutor = AudioSystem.getClip();
+                reprodutor.open(criaStream(som, formatoDeAudio));
+            }
+            catch(LineUnavailableException excecao)
+            {
+                LOGGER.log(Level.WARNING, "Não foi possível criar ou abrir uma linha de execução de áudio!", excecao);
+                reprodutor = null;
+            }
             this.endereco = endereco;
-            this.reprodutor = clip;
         }
 
         /**
@@ -283,6 +290,9 @@ public final class Sons extends Biblioteca
          */
         void setVolume(float volume)
         {
+            if (reprodutor == null )
+                return;
+
             this.volume = limitaValorDoVolume(volume);
 
             if (reprodutor.isControlSupported(FloatControl.Type.MASTER_GAIN))
@@ -312,11 +322,6 @@ public final class Sons extends Biblioteca
             setVolume(this.volume); //atualiza o volume
         }
 
-        public Clip getReprodutor()
-        {
-            return reprodutor;
-        }
-
         public float getVolume()
         {
             return volume;
@@ -329,6 +334,9 @@ public final class Sons extends Biblioteca
 
         public void inicia(boolean repetir)
         {
+            if (reprodutor == null )
+                return;
+            
             if (!repetir)
             {
                 reprodutor.start();
@@ -341,6 +349,9 @@ public final class Sons extends Biblioteca
 
         public void interrompe()
         {
+            if (reprodutor == null )
+                return;
+            
             reprodutor.stop();
         }
     }

--- a/test/br/univali/portugol/nucleo/bibliotecas/sons/TesteMultiplosSons.java
+++ b/test/br/univali/portugol/nucleo/bibliotecas/sons/TesteMultiplosSons.java
@@ -12,7 +12,7 @@ public class TesteMultiplosSons
     {
         Sons sons = new Sons();
 
-        for (int i = 0; i < 50; i++)
+        for (int i = 0; i < 32; i++)
         {
             System.out.println("Reproduzindo som " + i);
             Integer somDaIgnicao = sons.carregar_som("../Portugol-Studio-Recursos/exemplos/jogos/corrida/sons/som_ligar.mp3");

--- a/test/br/univali/portugol/nucleo/bibliotecas/sons/TesteMultiplosSons.java
+++ b/test/br/univali/portugol/nucleo/bibliotecas/sons/TesteMultiplosSons.java
@@ -1,0 +1,28 @@
+package br.univali.portugol.nucleo.bibliotecas.sons;
+
+import br.univali.portugol.nucleo.bibliotecas.Sons;
+
+/**
+ * @author elieser Esta classe testa se é possível criar vários sons simultâneos
+ * sem que ocorra uma LineUnavailableException.
+ */
+public class TesteMultiplosSons
+{
+    public static void main(String args[]) throws Exception
+    {
+        Sons sons = new Sons();
+
+        for (int i = 0; i < 50; i++)
+        {
+            System.out.println("Reproduzindo som " + i);
+            Integer somDaIgnicao = sons.carregar_som("../Portugol-Studio-Recursos/exemplos/jogos/corrida/sons/som_ligar.mp3");
+            Integer indiceDaReproducao = sons.reproduzir_som(somDaIgnicao, false);
+            if (indiceDaReproducao == null){
+                System.out.println("Índice da reprodução era nulo!");
+                System.exit(-1);
+            }
+            Thread.sleep(5);
+        }
+        Thread.sleep(10000);
+    }
+}


### PR DESCRIPTION
O motor de áudio estava gerando uma NullPointer exception. O problema principal é que as linhas de execução de áudio não estavam sendo finalizadas e os recursos de áudio da máquina eram esgotados rapidamente. 

@noschang , testei no Ubuntu e vi o erro que você reportou. Agora está funcionando. Não está perfeito, as vezes algumas execuções de uma das peças da bateria falham, mas não é nada muito sério. Agora quando acontece uma exceção por falta de recursos de áudio essa exceção é tratada internamente, assim a execução do programa não é interrompida. Acho que é melhor continuar executando e não ouvir uma determinada reprodução de áudio do que parar tudo.

Outro problema que no linux aparece mais fortemente é a mudança nos volumes. Pelo que eu percebi o java.sound deve usar uma thread para alterar os volumes, e essa alteração não acontece imediamente. Quando um som é muito curto (é o caso dos sons da bateria) pode acontecer do som terminar antes que o volume seja alterado, e nós não chegamos a ouvir a alteração de volume. Pra resolver isso acho que teria que abandonar toda a implementação atual e mixar os streams na mão, mas já fiz isso antes e o resultado não foi lá grande coisa :)