### PR TITLE
Corrigindo Issue #56 / #72 no Portugol Studio Leitura indevida de constantes

### DIFF
--- a/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
@@ -83,6 +83,8 @@ public final class AnalisadorSemantico implements VisitanteASA
     private boolean declarandoMatriz;
     private boolean passandoReferencia = false;
     private boolean passandoParametro = false;
+    
+    public final static String FUNCAO_LEIA = "leia";
 
     public AnalisadorSemantico()
     {
@@ -234,7 +236,7 @@ public final class AnalisadorSemantico implements VisitanteASA
 
         return null;
     }
-
+    
     @Override
     public Object visitar(NoChamadaFuncao chamadaFuncao) throws ExcecaoVisitaASA
     {
@@ -252,7 +254,16 @@ public final class AnalisadorSemantico implements VisitanteASA
     {
         List<ModoAcesso> modosAcessoEsperados = obterModosAcessoEsperados(chamadaFuncao);
         List<ModoAcesso> modosAcessoPassados = obterModosAcessoPassados(chamadaFuncao);
-
+        
+        //Se for a função leia, configura o modo de acesso esperado por referencia.
+        if(chamadaFuncao.getNome().equals(FUNCAO_LEIA)){
+            int qtdAcessosPassados = modosAcessoPassados.size();
+            
+            for(int indice = 0; indice < qtdAcessosPassados; indice++){
+                modosAcessoEsperados.add(ModoAcesso.POR_REFERENCIA);
+            }
+        }
+        
         int cont = Math.min(modosAcessoEsperados.size(), modosAcessoPassados.size());
 
         for (int indice = 0; indice < cont; indice++)
@@ -262,7 +273,7 @@ public final class AnalisadorSemantico implements VisitanteASA
 
             if (modoAcessoEsperado == ModoAcesso.POR_REFERENCIA && modoAcessoPassado == ModoAcesso.POR_VALOR)
             {
-                notificarErroSemantico(new ErroPassagemParametroInvalida(chamadaFuncao.getParametros().get(indice), obterNomeParametro(chamadaFuncao, indice), chamadaFuncao.getNome()));
+                notificarErroSemantico(new ErroPassagemParametroInvalida(chamadaFuncao.getParametros().get(indice), obterNomeParametro(chamadaFuncao, indice), chamadaFuncao.getNome(), indice));
             }
         }
     }
@@ -658,7 +669,7 @@ public final class AnalisadorSemantico implements VisitanteASA
 
                 try
                 {
-                    if (parametro instanceof NoReferenciaVariavel && chamadaFuncao.getNome().equals("leia"))
+                    if (parametro instanceof NoReferenciaVariavel && chamadaFuncao.getNome().equals(FUNCAO_LEIA))
                     {
                         String nome = ((NoReferenciaVariavel) parametro).getNome();
 
@@ -699,7 +710,8 @@ public final class AnalisadorSemantico implements VisitanteASA
     {
         int esperados = obterNumeroParametrosEsperados(chamadaFuncao);
         int passados = (chamadaFuncao.getParametros() != null) ? chamadaFuncao.getParametros().size() : 0;
-
+        
+        //Funções como leia e escreva aceitam numeros infinitos de parametros, mas não nenhum.
         if ((esperados == Integer.MAX_VALUE && passados == 0) || (esperados != Integer.MAX_VALUE && passados != esperados))
         {
             notificarErroSemantico(new ErroNumeroParametrosFuncao(passados, esperados, chamadaFuncao));
@@ -1976,7 +1988,7 @@ public final class AnalisadorSemantico implements VisitanteASA
     {
         List<String> funcoes = new ArrayList<String>();
 
-        funcoes.add("leia");
+        funcoes.add(FUNCAO_LEIA);
         funcoes.add("escreva");
         funcoes.add("limpa");
         
@@ -2259,4 +2271,6 @@ public final class AnalisadorSemantico implements VisitanteASA
     {
         throw new UnsupportedOperationException("Não implementado");
     }
+
+    
 }

--- a/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
@@ -58,11 +58,11 @@ public final class ErroPassagemParametroInvalida extends ErroSemantico
 
         if (nomeFuncao.equals(AnalisadorSemantico.FUNCAO_LEIA))
         {
-            construtorTexto.append("Não é possível passar uma expressão constante para a função ");
-            construtorTexto.append(AnalisadorSemantico.FUNCAO_LEIA);
-            construtorTexto.append(" altere ou remova o parametro na posição ");
+            construtorTexto.append("Não é possível passar um valor literal, constante ou expressão para o parâmetro na posição \"");
             construtorTexto.append(posicaoParametro+1);
-            construtorTexto.append(" da função");
+            construtorTexto.append("\"da função \"");
+            construtorTexto.append(AnalisadorSemantico.FUNCAO_LEIA);
+            construtorTexto.append("\" pois este parâmetro espera uma referência. Tente passar uma variável, vetor ou matriz para a função sem ser constante");
         }
         else
         {

--- a/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
@@ -1,5 +1,6 @@
 package br.univali.portugol.nucleo.analise.semantica.erros;
 
+import br.univali.portugol.nucleo.analise.semantica.AnalisadorSemantico;
 import br.univali.portugol.nucleo.asa.NoExpressao;
 import br.univali.portugol.nucleo.mensagens.ErroSemantico;
 
@@ -12,14 +13,16 @@ public final class ErroPassagemParametroInvalida extends ErroSemantico
     private NoExpressao valor;
     private String nomeParametro;
     private String nomeFuncao;
-
-    public ErroPassagemParametroInvalida(NoExpressao valor, String nomeParametro, String nomeFuncao)
+    private int posicaoParametro;
+    
+    public ErroPassagemParametroInvalida(NoExpressao valor, String nomeParametro, String nomeFuncao, int posicaoParametro)
     {
-        super(valor.getTrechoCodigoFonte(),"ErroSemantico.ErroPassagemParametroInvalida");
-        
+        super(valor.getTrechoCodigoFonte(), "ErroSemantico.ErroPassagemParametroInvalida");
+
         this.valor = valor;
         this.nomeParametro = nomeParametro;
         this.nomeFuncao = nomeFuncao;
+        this.posicaoParametro = posicaoParametro;
     }
 
     public NoExpressao getValor()
@@ -36,23 +39,40 @@ public final class ErroPassagemParametroInvalida extends ErroSemantico
     {
         return nomeFuncao;
     }
+
+    public int getPosicaoParametro()
+    {
+        return posicaoParametro;
+    }
     
-     /**
+    
+    /**
      * {@inheritDoc }
      */
     @Override
     protected String construirMensagem()
-    {        
+    {
         //return new ErroPassagemParametroInvalida.ConstrutorMensagem().construirMensagem();
-        
+
         StringBuilder construtorTexto = new StringBuilder();
-            
-        construtorTexto.append("Não é possível passar uma expressão constante para o parâmetro \"");
-        construtorTexto.append(nomeParametro);
-        construtorTexto.append("\" da função \"");
-        construtorTexto.append(nomeFuncao);
-        construtorTexto.append("\", pois este parâmetro espera uma referência");
-            
+
+        if (nomeFuncao.equals(AnalisadorSemantico.FUNCAO_LEIA))
+        {
+            construtorTexto.append("Não é possível passar uma expressão constante para a função ");
+            construtorTexto.append(AnalisadorSemantico.FUNCAO_LEIA);
+            construtorTexto.append(" altere ou remova o parametro na posição ");
+            construtorTexto.append(posicaoParametro+1);
+            construtorTexto.append(" da função");
+        }
+        else
+        {
+            construtorTexto.append("Não é possível passar uma expressão constante para o parâmetro \"");
+            construtorTexto.append(nomeParametro);
+            construtorTexto.append("\" da função \"");
+            construtorTexto.append(nomeFuncao);
+            construtorTexto.append("\", pois este parâmetro espera uma referência");
+        }
+
         return construtorTexto.toString();
     }
 }

--- a/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
@@ -60,7 +60,7 @@ public final class ErroPassagemParametroInvalida extends ErroSemantico
         {
             construtorTexto.append("Não é possível passar um valor literal, constante ou expressão para o parâmetro na posição \"");
             construtorTexto.append(posicaoParametro+1);
-            construtorTexto.append("\"da função \"");
+            construtorTexto.append("\" da função \"");
             construtorTexto.append(AnalisadorSemantico.FUNCAO_LEIA);
             construtorTexto.append("\", pois este parâmetro espera uma referência. Tente passar uma variável, vetor ou matriz para a função sem ser constante");
         }

--- a/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/erros/ErroPassagemParametroInvalida.java
@@ -62,7 +62,7 @@ public final class ErroPassagemParametroInvalida extends ErroSemantico
             construtorTexto.append(posicaoParametro+1);
             construtorTexto.append("\"da função \"");
             construtorTexto.append(AnalisadorSemantico.FUNCAO_LEIA);
-            construtorTexto.append("\" pois este parâmetro espera uma referência. Tente passar uma variável, vetor ou matriz para a função sem ser constante");
+            construtorTexto.append("\", pois este parâmetro espera uma referência. Tente passar uma variável, vetor ou matriz para a função sem ser constante");
         }
         else
         {


### PR DESCRIPTION
Na verificação semantica das chamadas de função, no método
"verificarModoAcesso" foi adicionado instruções para ele verificar
também na função leia se os parametros passados são por Referencia.

E foi modificado a exceção ErroPassagemParametroInvalida para apresentar
uma mensagem mais amigavel ao usuário quando ele passar constantes para
o comando leia.

https://github.com/UNIVALI-LITE/Portugol-Studio/issues/72
#56 