### PR TITLE
Otimização - Evitando checagens descenessárias nos pontos de parada

### DIFF
--- a/src/br/univali/portugol/nucleo/AtivadorDePontosDeParada.java
+++ b/src/br/univali/portugol/nucleo/AtivadorDePontosDeParada.java
@@ -55,11 +55,7 @@ import br.univali.portugol.nucleo.asa.NoSe;
 import br.univali.portugol.nucleo.asa.NoTitulo;
 import br.univali.portugol.nucleo.asa.NoVaPara;
 import br.univali.portugol.nucleo.asa.NoVetor;
-import br.univali.portugol.nucleo.asa.TrechoCodigoFonte;
 import br.univali.portugol.nucleo.asa.VisitanteASA;
-import br.univali.portugol.nucleo.execucao.Depurador;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -89,6 +85,11 @@ public final class AtivadorDePontosDeParada implements VisitanteASA
         return linhasDasParadas.contains(linhaDoNo);
     }
 
+    public boolean temPontosDeParadaAtivos()
+    {
+        return !linhasDasParadas.isEmpty();
+    }
+    
     /**
      *
      * @param linhasDosPontosDeParada As linhas onde serão aplicados os pontos

--- a/src/br/univali/portugol/nucleo/execucao/Depurador.java
+++ b/src/br/univali/portugol/nucleo/execucao/Depurador.java
@@ -25,9 +25,12 @@ public class Depurador extends Interpretador implements ObservadorMemoria
 
     private Programa programa;
     private Estado estado = Estado.PARADO;
-
-
+    private boolean otimizandoExecucao = false; // se não existirem pontos de parada o código que verifica as paradas não é executado
     
+    public void setExecucaoOtimizada(boolean otimiza)
+    {
+        this.otimizandoExecucao = otimiza;
+    }
     
     public Estado getEstado()
     {
@@ -619,6 +622,11 @@ public class Depurador extends Interpretador implements ObservadorMemoria
 
     private void realizarParada(NoBloco no, TrechoCodigoFonte trechoCodigoFonte) throws ExcecaoVisitaASA
     {
+        if (otimizandoExecucao) 
+        {
+            return; // a execução é otimizada quando não existem pontos de parada no código.
+        }
+        
         if (no.ehParavel(this.estado) || funcaoInicial(no))
         {
             if ( this.estado == Estado.STEP_INTO){


### PR DESCRIPTION
O código antigo sempre executava as verificações nos pontos de parada. Agora o depurador possui uma flag de otimização que é 'ligada' sempre que a execução está no modo BREAK_POINT (pontos de parada) mas não existem pontos de parada ativados na IDE.

@noschang , se puderes dar uma olhada rápida antes do merge eu agradeço :)