### PR TITLE
Corrigindo finalizacao de threads

### DIFF
--- a/src/br/univali/portugol/nucleo/execucao/gerador/helpers/Utils.java
+++ b/src/br/univali/portugol/nucleo/execucao/gerador/helpers/Utils.java
@@ -328,7 +328,7 @@ public class Utils
     public static void geraVerificacaoThreadInterrompida(PrintWriter saida, int nivelEscopo)
     {
         saida.append(Utils.geraIdentacao(nivelEscopo));
-        saida.append("if (Thread.currentThread().isInterrupted()) {throw new InterruptedException();}");
+        saida.append("if (this.interrupcaoSolicitada) {throw new InterruptedException();}");
         saida.println();
         saida.println();
     }

--- a/test/br/univali/portugol/nucleo/execucao/IntegracaoGeradorCodigoJavacTest.java
+++ b/test/br/univali/portugol/nucleo/execucao/IntegracaoGeradorCodigoJavacTest.java
@@ -45,9 +45,9 @@ public class IntegracaoGeradorCodigoJavacTest
         File[] dirs = dirExemplos.listFiles();
         for (File dir : dirs)
         {
-            //geraCodigo(dir);
+            geraCodigo(dir);
         }
-        geraCodigo(new File("../Portugol-Studio-Recursos/exemplos/bibliotecas/graficos/solar.por"));
+        //geraCodigo(new File("../Portugol-Studio-Recursos/exemplos/bibliotecas/graficos/solar.por"));
         //geraCodigo(new File("../Portugol-Studio-Recursos/exemplos/musica/bateria.por"));
     }
     


### PR DESCRIPTION
@noschang , não consegui descobrir porque a thread de execução não estava sendo interrompida no Mac. Solucionei usando uma flag **interrupcaoSolicitada** na classe Programa. Internamente os programas que são gerados verificam essa flag ao invés de verificarem *currentThread().isInterrupted()*. Funcionou sem problemas no Windows, Linux e Mac.