### PR TITLE
Corrigindo finalizacao da thread de execução dos programas

### DIFF
--- a/src/br/univali/portugol/nucleo/Programa.java
+++ b/src/br/univali/portugol/nucleo/Programa.java
@@ -86,6 +86,7 @@ public abstract class Programa
     private volatile boolean leituraIgnorada = false;
 
     protected volatile boolean interrupcaoSolicitada = false;
+    private Future controleExecucao;
     
     private final Object LOCK = new Object();
     
@@ -502,7 +503,8 @@ public abstract class Programa
             this.estado = estado;
             this.interrupcaoSolicitada = false;
             tarefaExecucao = new TarefaExecucao(parametros);
-            POOL_DE_THREADS.submit(tarefaExecucao);
+            controleExecucao = POOL_DE_THREADS.submit(tarefaExecucao);
+            
         }
     }
 
@@ -656,6 +658,7 @@ public abstract class Programa
     {
         if (isExecutando())
         {
+            controleExecucao.cancel(true);
             interrupcaoSolicitada = true;
         }
     }
@@ -901,6 +904,7 @@ public abstract class Programa
     private void notificarEncerramentoExecucao(ResultadoExecucao resultadoExecucao)
     {
         tarefaExecucao = null;
+        controleExecucao = null;
 
         for (ObservadorExecucao observador : observadores)
         {

--- a/src/br/univali/portugol/nucleo/execucao/gerador/helpers/Utils.java
+++ b/src/br/univali/portugol/nucleo/execucao/gerador/helpers/Utils.java
@@ -328,7 +328,7 @@ public class Utils
     public static void geraVerificacaoThreadInterrompida(PrintWriter saida, int nivelEscopo)
     {
         saida.append(Utils.geraIdentacao(nivelEscopo));
-        saida.append("if (this.interrupcaoSolicitada) {throw new InterruptedException();}");
+        saida.append("if (this.interrupcaoSolicitada || Thread.currentThread().isInterrupted()) {throw new InterruptedException();}");
         saida.println();
         saida.println();
     }


### PR DESCRIPTION
Esse pull request implementa a interrupção da thread de execução (como era feito anteriormente). Sem a interrupção da thread chamadas para **wait()** nunca terminam e os programas não finalizam. As bibliotecas Mouse e Teclado usam **wait()** em vários momentos, por exemplo.

No Mac havia um bug na finalização dos programas, a thread não estava sendo interrompida. Foi adicionada uma [flag](https://github.com/UNIVALI-LITE/Portugol-Nucleo/blob/master/src/br/univali/portugol/nucleo/Programa.java#L88) para finalizar o programa mesmo quando a thread não é interrompida corretamente. Essa solução foi adotada apenas porque não foi possível identificar o problema da Não-interrupção das threads no Mac. 