### PR TITLE
Corrigindo parâmetros da função leia

### DIFF
--- a/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Esta classe percorre a ASA gerada a partir do código fonte para detectar
@@ -28,6 +30,8 @@ import java.util.TreeMap;
  */
 public final class AnalisadorSemantico implements VisitanteASA
 {
+    private static final Logger LOGGER = Logger.getLogger(AnalisadorSemantico.class.getName());
+    
     private static final List<String> FUNCOES_RESERVADAS = getLista();
 
     private final Memoria memoria;
@@ -225,11 +229,12 @@ public final class AnalisadorSemantico implements VisitanteASA
         
         if (chamadaFuncao.getNome().equals(FUNCAO_LEIA))
         {
+            cont = modosAcessoPassados.size();// a função leia retorna uma lista vazia em modos de acesso esperados
             for (int indice = 0; indice < cont; indice++)
             {
                 NoExpressao parametro = chamadaFuncao.getParametros().get(indice);
-                
-                if (!(parametro instanceof NoReferenciaVariavel) && (parametro instanceof NoReferenciaVetor) && (parametro instanceof NoReferenciaMatriz))
+                boolean parametroValido = parametro instanceof NoReferenciaVariavel || parametro instanceof NoReferenciaVetor || parametro instanceof NoReferenciaMatriz;
+                if (!parametroValido)
                 {
                     notificarErroSemantico(new ErroPassagemParametroInvalida(chamadaFuncao.getParametros().get(indice), obterNomeParametro(chamadaFuncao, indice), chamadaFuncao.getNome(), indice));
                 }
@@ -320,6 +325,7 @@ public final class AnalisadorSemantico implements VisitanteASA
                 catch (ExcecaoSimboloNaoDeclarado ex)
                 {
                     // Não faz nada aqui
+                    LOGGER.log(Level.SEVERE, null, ex);
                 }
             }
         }

--- a/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
@@ -234,6 +234,12 @@ public final class AnalisadorSemantico implements VisitanteASA
             {
                 NoExpressao parametro = chamadaFuncao.getParametros().get(indice);
                 boolean parametroValido = parametro instanceof NoReferenciaVariavel || parametro instanceof NoReferenciaVetor || parametro instanceof NoReferenciaMatriz;
+
+                // verifica se o usuário está tentando usar uma constante na função LEIA
+                if (parametroValido && parametro instanceof NoReferenciaVariavel) {
+                    NoDeclaracao origemDaReferencia = ((NoReferenciaVariavel)parametro).getOrigemDaReferencia();
+                    parametroValido = !origemDaReferencia.constante();
+                }
                 if (!parametroValido)
                 {
                     notificarErroSemantico(new ErroPassagemParametroInvalida(chamadaFuncao.getParametros().get(indice), obterNomeParametro(chamadaFuncao, indice), chamadaFuncao.getNome(), indice));

--- a/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
+++ b/src/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemantico.java
@@ -238,7 +238,8 @@ public final class AnalisadorSemantico implements VisitanteASA
                 // verifica se o usuário está tentando usar uma constante na função LEIA
                 if (parametroValido && parametro instanceof NoReferenciaVariavel) {
                     NoDeclaracao origemDaReferencia = ((NoReferenciaVariavel)parametro).getOrigemDaReferencia();
-                    parametroValido = !origemDaReferencia.constante();
+                    parametroValido = origemDaReferencia != null && !origemDaReferencia.constante();
+                        
                 }
                 if (!parametroValido)
                 {

--- a/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
+++ b/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 public final class AnalisadorSemanticoTest
 {
-
+    
     @Test (expected = ErroCompilacao.class)
     public void testFuncaoLeiaComFuncao() throws ErroCompilacao {
         
@@ -28,6 +28,19 @@ public final class AnalisadorSemanticoTest
         );
     }
 
+    @Test (expected = ErroCompilacao.class)
+    public void testFuncaoLeiaComVariavelConstante() throws ErroCompilacao {
+        
+        Portugol.compilarParaAnalise(
+                "programa                       "
+                + "{                            "
+                + " funcao inicio(){            "
+                + "   const inteiro x = 1       "
+                + "   leia(x)                   "
+                + " }                           "
+                + "}                            "
+        );
+    }
 
     @Test (expected = ErroCompilacao.class)
     public void testFuncaoLeiaComConstante() throws ErroCompilacao {

--- a/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
+++ b/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
@@ -38,6 +38,30 @@ public final class AnalisadorSemanticoTest
         }
     }
     
+    @Test
+    public void testFuncaoLeiaComVariasVariaveis() {
+        try
+        {
+            Programa programa = Portugol.compilarParaAnalise(
+                    "programa                       "
+                    + "{                            "
+                    + " funcao inicio(){            "
+                    + "   inteiro a,b,c                 "
+                    + "   leia(a,b,c)                   "
+                    + " }                           "
+                    + "}                            "
+            );
+
+            ResultadoAnalise resultado = programa.getResultadoAnalise();
+            
+            assertTrue("O programa deveria ter compilado sem erros e avisos", resultado.getAvisos().isEmpty() && resultado.getErros().isEmpty());
+        }
+        catch (Exception ex)
+        {
+            fail(ex.getMessage());
+        }
+    }
+    
      @Test
     public void testReferenciaMatriz()
     {

--- a/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
+++ b/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
@@ -29,6 +29,19 @@ public final class AnalisadorSemanticoTest
     }
 
     @Test (expected = ErroCompilacao.class)
+    public void testFuncaoLeiaComConstanteDeBiblioteca() throws ErroCompilacao {
+        
+        Portugol.compilarParaAnalise(
+                "programa                       "
+                + "{ inclua biblioteca Graficos "
+                + " funcao inicio(){            "
+                + "   leia(Graficos.COR_AMARELO)"
+                + " }                           "
+                + "}                            "
+        );
+    }
+    
+    @Test (expected = ErroCompilacao.class)
     public void testFuncaoLeiaComVariavelConstante() throws ErroCompilacao {
         
         Portugol.compilarParaAnalise(

--- a/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
+++ b/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
@@ -2,6 +2,7 @@ package br.univali.portugol.nucleo.analise.semantica;
 
 import br.univali.portugol.nucleo.ErroCompilacao;
 import br.univali.portugol.nucleo.Portugol;
+import br.univali.portugol.nucleo.Programa;
 import br.univali.portugol.nucleo.analise.ResultadoAnalise;
 import br.univali.portugol.nucleo.analise.semantica.erros.ErroSimboloNaoDeclarado;
 import br.univali.portugol.nucleo.analise.semantica.erros.ErroSimboloNaoInicializado;
@@ -13,6 +14,30 @@ import org.junit.Test;
 public final class AnalisadorSemanticoTest
 {
 
+    @Test
+    public void testFuncaoLeiaComVariavel() {
+        try
+        {
+            Programa programa = Portugol.compilarParaAnalise(
+                    "programa                       "
+                    + "{                            "
+                    + " funcao inicio(){            "
+                    + "   inteiro a                 "
+                    + "   leia(a)                   "
+                    + " }                           "
+                    + "}                            "
+            );
+
+            ResultadoAnalise resultado = programa.getResultadoAnalise();
+            
+            assertTrue("O programa deveria ter compilado sem erros e avisos", resultado.getAvisos().isEmpty() && resultado.getErros().isEmpty());
+        }
+        catch (Exception ex)
+        {
+            fail(ex.getMessage());
+        }
+    }
+    
      @Test
     public void testReferenciaMatriz()
     {

--- a/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
+++ b/test/br/univali/portugol/nucleo/analise/semantica/AnalisadorSemanticoTest.java
@@ -14,6 +14,95 @@ import org.junit.Test;
 public final class AnalisadorSemanticoTest
 {
 
+    @Test (expected = ErroCompilacao.class)
+    public void testFuncaoLeiaComFuncao() throws ErroCompilacao {
+        
+        Portugol.compilarParaAnalise(
+            "    programa {             " +
+            "	funcao inicio() {       " +
+            "		leia(teste())   " +
+            "	}                       " +
+            "                           " +
+            "	funcao teste(){}        " +
+            "}"
+        );
+    }
+
+
+    @Test (expected = ErroCompilacao.class)
+    public void testFuncaoLeiaComConstante() throws ErroCompilacao {
+        
+        Portugol.compilarParaAnalise(
+                "programa                       "
+                + "{                            "
+                + " funcao inicio(){            "
+                + "   leia(10)                   "
+                + " }                           "
+                + "}                            "
+        );
+    }
+    
+    @Test (expected = ErroCompilacao.class)
+    public void testFuncaoLeiaSemParametros() throws ErroCompilacao {
+        // a função leia não pode ser usada sem parametros
+        Portugol.compilarParaAnalise(
+                "programa                       "
+                + "{                            "
+                + " funcao inicio(){            "
+                + "   leia()                   "
+                + " }                           "
+                + "}                            "
+        );
+    }
+    
+    @Test
+    public void testFuncaoLeiaComMatriz() {
+        try
+        {
+            Programa programa = Portugol.compilarParaAnalise(
+                    "programa                       "
+                    + "{                            "
+                    + " funcao inicio(){            "
+                    + "   inteiro a[3][2]                 "
+                    + "   leia(a[0][0])                   "
+                    + " }                           "
+                    + "}                            "
+            );
+            
+            ResultadoAnalise resultado = programa.getResultadoAnalise();
+            
+            assertTrue("O programa deveria ter compilado sem erros e avisos", !resultado.contemAvisos() && !resultado.contemErros());
+        }
+        catch (Exception ex)
+        {
+            fail(ex.getMessage());
+        }
+    }
+    
+    @Test
+    public void testFuncaoLeiaComVetor() {
+        try
+        {
+            Programa programa = Portugol.compilarParaAnalise(
+                    "programa                       "
+                    + "{                            "
+                    + " funcao inicio(){            "
+                    + "   inteiro a[3]                 "
+                    + "   leia(a[0])                   "
+                    + " }                           "
+                    + "}                            "
+            );
+            
+            ResultadoAnalise resultado = programa.getResultadoAnalise();
+            
+            assertTrue("O programa deveria ter compilado sem erros e avisos", !resultado.contemAvisos() && !resultado.contemErros());
+        }
+        catch (Exception ex)
+        {
+            fail(ex.getMessage());
+        }
+    }
+    
     @Test
     public void testFuncaoLeiaComVariavel() {
         try
@@ -27,10 +116,10 @@ public final class AnalisadorSemanticoTest
                     + " }                           "
                     + "}                            "
             );
-
+            
             ResultadoAnalise resultado = programa.getResultadoAnalise();
             
-            assertTrue("O programa deveria ter compilado sem erros e avisos", resultado.getAvisos().isEmpty() && resultado.getErros().isEmpty());
+            assertTrue("O programa deveria ter compilado sem erros e avisos", !resultado.contemAvisos() && !resultado.contemErros());
         }
         catch (Exception ex)
         {
@@ -54,7 +143,7 @@ public final class AnalisadorSemanticoTest
 
             ResultadoAnalise resultado = programa.getResultadoAnalise();
             
-            assertTrue("O programa deveria ter compilado sem erros e avisos", resultado.getAvisos().isEmpty() && resultado.getErros().isEmpty());
+            assertTrue("O programa deveria ter compilado sem erros e avisos", !resultado.contemAvisos() && !resultado.contemErros());
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Corrigindo o semântico para não aceitar constantes ou funções como parâmetros na função leia.

