### PR TITLE
Aumentando pool de Operações de 2048 para 131072

### DIFF
--- a/src/br/univali/portugol/nucleo/bibliotecas/graficos/SuperficieDesenhoImpl.java
+++ b/src/br/univali/portugol/nucleo/bibliotecas/graficos/SuperficieDesenhoImpl.java
@@ -30,7 +30,7 @@ final class SuperficieDesenhoImpl extends Canvas implements SuperficieDesenho
 {
     private final PoolOperacoesGraficas POOL_OPERACOES_GRAFICAS = new PoolOperacoesGraficas();
 
-    private final OperacaoGrafica[] operacoes = new OperacaoGrafica[2048];
+    private final OperacaoGrafica[] operacoes = new OperacaoGrafica[131072];
     private int indiceOperacao = 0;
 
     private Font fonteTexto = null;

--- a/src/br/univali/portugol/nucleo/bibliotecas/graficos/SuperficieDesenhoImpl.java
+++ b/src/br/univali/portugol/nucleo/bibliotecas/graficos/SuperficieDesenhoImpl.java
@@ -30,7 +30,7 @@ final class SuperficieDesenhoImpl extends Canvas implements SuperficieDesenho
 {
     private final PoolOperacoesGraficas POOL_OPERACOES_GRAFICAS = new PoolOperacoesGraficas();
 
-    private final OperacaoGrafica[] operacoes = new OperacaoGrafica[131072];
+    private final OperacaoGrafica[] operacoes = new OperacaoGrafica[PoolOperacoesGraficas.QUANTIDADE_MAXIMA_OPERACOES];
     private int indiceOperacao = 0;
 
     private Font fonteTexto = null;

--- a/src/br/univali/portugol/nucleo/bibliotecas/graficos/operacoes/PoolOperacoesGraficas.java
+++ b/src/br/univali/portugol/nucleo/bibliotecas/graficos/operacoes/PoolOperacoesGraficas.java
@@ -22,7 +22,7 @@ import java.awt.image.BufferedImage;
  */
 public final class PoolOperacoesGraficas
 {
-    private static final int QUANTIDADE_MAXIMA_OPERACOES = 2048;
+    private static final int QUANTIDADE_MAXIMA_OPERACOES = 131072;
     private static final int QUANTIDADE_INICIAL_OPERACOES = 8;
 
     private final CacheOperacoesDesenhoElipse CACHE_OPERACOES_DESENHO_ELIPSE;

--- a/src/br/univali/portugol/nucleo/bibliotecas/graficos/operacoes/PoolOperacoesGraficas.java
+++ b/src/br/univali/portugol/nucleo/bibliotecas/graficos/operacoes/PoolOperacoesGraficas.java
@@ -22,7 +22,7 @@ import java.awt.image.BufferedImage;
  */
 public final class PoolOperacoesGraficas
 {
-    private static final int QUANTIDADE_MAXIMA_OPERACOES = 131072;
+    public static final int QUANTIDADE_MAXIMA_OPERACOES = 131072;
     private static final int QUANTIDADE_INICIAL_OPERACOES = 8;
 
     private final CacheOperacoesDesenhoElipse CACHE_OPERACOES_DESENHO_ELIPSE;


### PR DESCRIPTION
Porque alguns exemplos davam "out off bounds" e não fica legal pro 3D
Resolve o problema com o Exemplo **Fractal** da Issue https://github.com/UNIVALI-LITE/Portugol-Studio/issues/183


